### PR TITLE
Remove the chimp entry from optional dependencies in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,11 +32,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-chimp = ["chimp@git+https://github.com/simonpf/chimp", "torch", "xarray"]
 doc = ["sphinx", "sphinx_rtd_theme"]
 hooks = ["pre-commit", "ruff"]
 tests = ["pytest", "pytest-cov"]
-dev = ["monkey-wrench[chimp,doc,hooks,tests]"]
+dev = ["monkey-wrench[doc,hooks,tests]"]
 
 [project.scripts]
 monkey-wrench = "monkey_wrench.cli:run"


### PR DESCRIPTION
The chimp entry is no longer needed as the conda environment takes care of that.