### PR TITLE
Fix Satpy import deprecation warnings

### DIFF
--- a/monkey_wrench/input_output/seviri/_models.py
+++ b/monkey_wrench/input_output/seviri/_models.py
@@ -12,8 +12,8 @@ from fsspec import open_files
 from loguru import logger
 from pydantic import ConfigDict, NonNegativeInt, validate_call
 from satpy import Scene
-from satpy.readers.seviri_base import CHANNEL_NAMES
-from satpy.readers.utils import FSFile
+from satpy.readers.core.seviri import CHANNEL_NAMES
+from satpy.readers.core.utils import FSFile
 
 from monkey_wrench.date_time import SeviriIDParser
 from monkey_wrench.generic import Function


### PR DESCRIPTION
This PR addresses the following warnings:

```
monkey_wrench/input_output/seviri/_models.py:15
  monkey-wrench/monkey_wrench/input_output/seviri/_models.py:15: UserWarning: 'satpy.readers.seviri_base.CHANNEL_NAMES' has been moved to 'satpy.readers.core.seviri.CHANNEL_NAMES'. Import from the new location instead (ex. 'from satpy.readers.core.seviri import CHANNEL_NAMES'). The old import paths will be removed in Satpy 1.0
    from satpy.readers.seviri_base import CHANNEL_NAMES

monkey_wrench/input_output/seviri/_models.py:16
  monkey-wrench/monkey_wrench/input_output/seviri/_models.py:16: UserWarning: 'satpy.readers.utils.FSFile' has been moved to 'satpy.readers.core.utils.FSFile'. Import from the new location instead (ex. 'from satpy.readers.core.utils import FSFile'). The old import paths will be removed in Satpy 1.0
    from satpy.readers.utils import FSFile
```